### PR TITLE
feat: add SQLite persistent data model for activities

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -31,20 +31,34 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister a student from an activity                           |
 
 ## Data Model
 
-The application uses a simple data model with meaningful identifiers:
+The application uses a persistent SQLite data model (`src/data/school.sqlite`) with meaningful identifiers:
 
-1. **Activities** - Uses activity name as identifier:
+1. **Users** - Uses email as identifier:
+
+   - Role (`student_viewer` by default)
+
+2. **Clubs** - Groups activities under a shared domain:
+
+   - Name
+   - Description
+
+3. **Activities** - Uses activity name as identifier:
 
    - Description
    - Schedule
    - Maximum number of participants allowed
-   - List of student emails who are signed up
+   - Club relationship
 
-2. **Students** - Uses email as identifier:
-   - Name
-   - Grade level
+4. **Enrollments** - Links users to activities:
+   - Prevents duplicate signups at the DB level
+   - Enables persistent participant tracking
 
-All data is stored in memory, which means data will be reset when the server restarts.
+## Initialization Strategy
+
+- On startup, the app creates tables if they do not exist.
+- If the activities table is empty, the app seeds initial activities and participant enrollments.
+- Existing databases are left intact, so data survives server restarts.

--- a/src/app.py
+++ b/src/app.py
@@ -1,81 +1,240 @@
-"""
-High School Management System API
+"""High School Management System API with SQLite persistence."""
 
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
-"""
-
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
-import os
+import sqlite3
 from pathlib import Path
 
-app = FastAPI(title="Mergington High School API",
-              description="API for viewing and signing up for extracurricular activities")
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
 
-# Mount the static files directory
-current_dir = Path(__file__).parent
-app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
-          "static")), name="static")
+app = FastAPI(
+    title="Mergington High School API",
+    description="API for viewing and signing up for extracurricular activities",
+)
 
-# In-memory activity database
-activities = {
+BASE_DIR = Path(__file__).parent
+DB_DIR = BASE_DIR / "data"
+DB_PATH = DB_DIR / "school.sqlite"
+
+app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
+
+SEED_ACTIVITIES = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
     },
     "Programming Class": {
         "description": "Learn programming fundamentals and build software projects",
         "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
         "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+        "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
     },
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"],
     },
     "Soccer Team": {
         "description": "Join the school soccer team and compete in matches",
         "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
         "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"],
     },
     "Basketball Team": {
         "description": "Practice and play basketball with the school team",
         "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"],
     },
     "Art Club": {
         "description": "Explore your creativity through painting and drawing",
         "schedule": "Thursdays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
     },
     "Drama Club": {
         "description": "Act, direct, and produce plays and performances",
         "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
         "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
     },
     "Math Club": {
         "description": "Solve challenging problems and participate in math competitions",
         "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
         "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
     },
     "Debate Team": {
         "description": "Develop public speaking and argumentation skills",
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
+        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+    },
 }
+
+
+def get_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def initialize_database() -> None:
+    DB_DIR.mkdir(parents=True, exist_ok=True)
+
+    with get_connection() as conn:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT NOT NULL UNIQUE,
+                role TEXT NOT NULL DEFAULT 'student_viewer',
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+
+            CREATE TABLE IF NOT EXISTS clubs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+
+            CREATE TABLE IF NOT EXISTS activities (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                club_id INTEGER,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT NOT NULL,
+                schedule TEXT NOT NULL,
+                max_participants INTEGER NOT NULL CHECK (max_participants > 0),
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (club_id) REFERENCES clubs(id) ON DELETE SET NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS enrollments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                activity_id INTEGER NOT NULL,
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+                FOREIGN KEY (activity_id) REFERENCES activities(id) ON DELETE CASCADE,
+                UNIQUE(user_id, activity_id)
+            );
+            """
+        )
+
+        existing_activity_count = conn.execute(
+            "SELECT COUNT(*) AS count FROM activities"
+        ).fetchone()["count"]
+
+        if existing_activity_count > 0:
+            return
+
+        conn.execute(
+            "INSERT INTO clubs(name, description) VALUES (?, ?)",
+            ("General Activities", "Default club for school-wide activities"),
+        )
+        club_id = conn.execute(
+            "SELECT id FROM clubs WHERE name = ?",
+            ("General Activities",),
+        ).fetchone()["id"]
+
+        for activity_name, activity in SEED_ACTIVITIES.items():
+            conn.execute(
+                """
+                INSERT INTO activities(club_id, name, description, schedule, max_participants)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    club_id,
+                    activity_name,
+                    activity["description"],
+                    activity["schedule"],
+                    activity["max_participants"],
+                ),
+            )
+            activity_id = conn.execute(
+                "SELECT id FROM activities WHERE name = ?",
+                (activity_name,),
+            ).fetchone()["id"]
+
+            for email in activity["participants"]:
+                conn.execute(
+                    "INSERT OR IGNORE INTO users(email, role) VALUES (?, 'student_viewer')",
+                    (email,),
+                )
+                user_id = conn.execute(
+                    "SELECT id FROM users WHERE email = ?",
+                    (email,),
+                ).fetchone()["id"]
+                conn.execute(
+                    "INSERT OR IGNORE INTO enrollments(user_id, activity_id) VALUES (?, ?)",
+                    (user_id, activity_id),
+                )
+
+
+def fetch_activities() -> dict[str, dict[str, object]]:
+    with get_connection() as conn:
+        rows = conn.execute(
+            """
+            SELECT
+                a.id,
+                a.name,
+                a.description,
+                a.schedule,
+                a.max_participants,
+                u.email AS participant_email
+            FROM activities AS a
+            LEFT JOIN enrollments AS e ON e.activity_id = a.id
+            LEFT JOIN users AS u ON u.id = e.user_id
+            ORDER BY a.name, u.email
+            """
+        ).fetchall()
+
+    activities: dict[str, dict[str, object]] = {}
+    for row in rows:
+        name = row["name"]
+        if name not in activities:
+            activities[name] = {
+                "description": row["description"],
+                "schedule": row["schedule"],
+                "max_participants": row["max_participants"],
+                "participants": [],
+            }
+        if row["participant_email"]:
+            activities[name]["participants"].append(row["participant_email"])
+
+    return activities
+
+
+def get_activity_capacity(activity_name: str) -> tuple[int, int]:
+    with get_connection() as conn:
+        row = conn.execute(
+            """
+            SELECT
+                a.id AS activity_id,
+                a.max_participants,
+                COUNT(e.id) AS current_participants
+            FROM activities AS a
+            LEFT JOIN enrollments AS e ON e.activity_id = a.id
+            WHERE a.name = ?
+            GROUP BY a.id, a.max_participants
+            """,
+            (activity_name,),
+        ).fetchone()
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    return row["activity_id"], row["max_participants"] - row["current_participants"]
+
+
+@app.on_event("startup")
+def startup() -> None:
+    initialize_database()
 
 
 @app.get("/")
@@ -85,48 +244,62 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return fetch_activities()
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    activity_id, slots_remaining = get_activity_capacity(activity_name)
+    if slots_remaining <= 0:
+        raise HTTPException(status_code=400, detail="Activity is full")
 
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
+    with get_connection() as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO users(email, role) VALUES (?, 'student_viewer')",
+            (email,),
         )
+        user_row = conn.execute(
+            "SELECT id FROM users WHERE email = ?",
+            (email,),
+        ).fetchone()
 
-    # Add student
-    activity["participants"].append(email)
+        try:
+            conn.execute(
+                "INSERT INTO enrollments(user_id, activity_id) VALUES (?, ?)",
+                (user_row["id"], activity_id),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise HTTPException(status_code=400, detail="Student is already signed up") from exc
+
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    activity_id, _ = get_activity_capacity(activity_name)
 
-    # Get the specific activity
-    activity = activities[activity_name]
+    with get_connection() as conn:
+        user_row = conn.execute(
+            "SELECT id FROM users WHERE email = ?",
+            (email,),
+        ).fetchone()
+        if user_row is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is not signed up for this activity",
+            )
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
+        result = conn.execute(
+            "DELETE FROM enrollments WHERE user_id = ? AND activity_id = ?",
+            (user_row["id"], activity_id),
         )
 
-    # Remove student
-    activity["participants"].remove(email)
+        if result.rowcount == 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is not signed up for this activity",
+            )
+
     return {"message": f"Unregistered {email} from {activity_name}"}


### PR DESCRIPTION
## Summary
Implements issue #8 by replacing in-memory activity storage with a persistent SQLite-backed data model while preserving existing API behavior.

## What Changed
- Added SQLite persistence in `src/app.py` with startup initialization.
- Added core entities/tables:
  - `users`
  - `clubs`
  - `activities`
  - `enrollments`
- Added seed/init strategy:
  - Creates schema on startup if missing.
  - Seeds existing activities/participants when DB is empty.
- Kept endpoint compatibility:
  - `GET /activities`
  - `POST /activities/{activity_name}/signup?email=...`
  - `DELETE /activities/{activity_name}/unregister?email=...`
- Enforced data integrity:
  - Duplicate enrollments prevented at DB level (`UNIQUE(user_id, activity_id)`).
  - Capacity checks enforced before signup.
- Updated `src/README.md` with persistent data model and initialization notes.

## Notes
- Uses local DB file: `src/data/school.sqlite`.
- Existing behavior is preserved, but data now survives restarts.

Closes #8